### PR TITLE
Update dependencies and fix pytest import path

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-black==24.3.0
-cuda-core[cu12]
-dvr-scan[opencv-headless]
-opencv-python
-pylint==3.0.3
-pytest
+black==24.8.0
+cuda-core[cu12]==0.4.0
+dvr-scan==1.8.1
+opencv-python==4.12.0.88
+pylint==3.2.6
+pytest==8.3.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Pytest configuration for ensuring package imports."""
+
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path for absolute imports
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))


### PR DESCRIPTION
## Summary
- bump core tooling dependencies to their latest compatible releases
- correct the DVR-Scan requirement to drop the unsupported opencv-headless extra
- ensure pytest can import the package modules by adding the repository root to sys.path

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fc27e4bfec8321b95eb77cad0ce15a